### PR TITLE
Add TLS support - currently lib doesn't work with HTTPS endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Hi,

Thank you for your work on this client.
[MCP server](https://github.com/gbrigandi/mcp-server-cortex) that is currently using this lib fails to work with HTTPS cortex endpoints, and prints the following error:

`2025-07-04T12:18:50.074862Z ERROR mcp_server_cortex::common: Error fetching analyzer instances: Reqwest(reqwest::Error { kind: Request, url: "https://cortex.com/api/analyzer/_search", source: hyper_util::client::legacy::Error(Connect, ConnectError("invalid URL, scheme is not http")) })`

I'm not very proficient in Rust so apologies if suggested fix is not working as it should.